### PR TITLE
fixes error h5presizer.js not found for core h5p

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -77,9 +77,10 @@ class filter_h5p extends moodle_text_filter {
                     $h5pparams = [
                             'url' => $fileurl,
                             'preventredirect' => true,
-                            'component' => '', //$component,
+                            'component' => 'mod_h5pactivity', //$component,
                         ];
-
+                    
+                    // Not sure if this is needed. It is not part of the url in embed code.
                     $optparams = ['frame', 'export', 'embed', 'copyright'];
                     foreach ($optparams as $optparam) {
                         if (!empty($config->$optparam)) {

--- a/templates/embed-h5p.mustache
+++ b/templates/embed-h5p.mustache
@@ -42,4 +42,4 @@
    allowfullscreen="allowfullscreen" class="h5p-player w-100 border-0">
    {{embedurl}}
 </iframe>
-<script src="{{wwwroot}}h5p/h5plib/v124/joubel/core/js/h5p-resizer.js" charset="UTF-8"></script>
+<script src="{{wwwroot}}/h5p/h5plib/v124/joubel/core/js/h5p-resizer.js" charset="UTF-8"></script>

--- a/templates/embed-h5p.mustache
+++ b/templates/embed-h5p.mustache
@@ -42,4 +42,4 @@
    allowfullscreen="allowfullscreen" class="h5p-player w-100 border-0">
    {{embedurl}}
 </iframe>
-<script src="{{wwwroot}}/mod/hvp/library/js/h5p-resizer.js" charset="UTF-8"></script>
+<script src="{{wwwroot}}h5p/h5plib/v124/joubel/core/js/h5p-resizer.js" charset="UTF-8"></script>

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2021062200;
-$plugin->requires = 2019052000;
+$plugin->version  = 2023090100;
+$plugin->requires = 2022111800;
 $plugin->component = 'filter_h5p';
-$plugin->release = '1.2 (Build: 2021062200)';
+$plugin->release = '1.3 (Build: 2023090100)';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
use core/h5p/h5presizer for core H5P instead of mod_hvp's 
An error appears if mod_hvp is not installed in the system. There is no need to use the hvp resizer, moodles core h5presizer does a good job. 
Testet on Moodle 4.1 